### PR TITLE
Add custom text color, custom box shadow

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -6,9 +6,9 @@
 	--better-findbar-position-bottom: 15px;
 	--better-findbar-position-left: 50%;
 	--better-findbar-position-right: auto;
-	--better-findbar-background-color: var(--zen-primary-color);
-	--better-findbar-text-color: var(--zen-secondary-color);
-	--better-findbar-box-shadow: var(--box-shadow-10);
+	--better-findbar-background-color: var(--zen-colors-primary);
+	--better-findbar-text-color: var(--zen-colors-secondary);
+	--better-findbar-box-shadow: 0 5px 10px rgba(0,0,0,0.5);
 }
 
 /* Custom background */

--- a/chrome.css
+++ b/chrome.css
@@ -7,12 +7,28 @@
 	--better-findbar-position-left: 50%;
 	--better-findbar-position-right: auto;
 	--better-findbar-background-color: var(--zen-primary-color);
+	--better-findbar-text-color: var(--zen-secondary-color);
+	--better-findbar-box-shadow: var(--box-shadow-10);
 }
 
 /* Custom background */
 @media (-moz-bool-pref: "theme-better_find_bar-enable_custom_background") {
 	:root {
 		--better-findbar-background-color: var(--theme-better_find_bar-custom_background);
+	}
+}
+
+/* Custom text color */
+@media (-moz-bool-pref: "theme-better_find_bar-enable_custom_text_color") {
+	:root {
+		--better-findbar-text-color: var(--theme-better_find_bar-custom_text_color);
+	}
+}
+
+/* Custom box shadow */
+@media (-moz-bool-pref: "theme-better_find_bar-enable_custom_box_shadow") {
+	:root {
+		--better-findbar-box-shadow: var(--theme-better_find_bar-custom_box_shadow);
 	}
 }
 
@@ -35,10 +51,16 @@ findbar {
 	transform: translateX(var(--better-findbar-transform-translateX)) translateY(0);
 
 	overflow: unset !important;
-	box-shadow: var(--box-shadow-10);
+	box-shadow: var(--better-findbar-box-shadow);
 
 	background: var(--better-findbar-background-color) !important;
-	border: 1px solid var(--input-border-color) !important;
+	color: var(--better-findbar-text-color) !important;
+	border: 1px solid
+		color-mix(
+			in hsl,
+			var(--better-findbar-background-color) 75%,
+			var(--better-findbar-text-color)
+		) !important;
 
 	transition: transform 0.35s ease !important;
 
@@ -58,9 +80,36 @@ findbar {
 
 		& .findbar-textbox {
 			flex-grow: 1;
+			background: var(--better-findbar-background-color) !important;
+			color: var(--better-findbar-text-color) !important;
+			border: 1px solid
+				color-mix(
+					in hsl,
+					var(--better-findbar-background-color),
+					var(--better-findbar-text-color) 50%
+				) !important;
+
+			&[status="notfound"] {
+				background-color: color-mix(
+					in srgb,
+					var(--better-findbar-background-color),
+					red 50%
+				) !important;
+				color: inherit;
+			}
 		}
 	}
 
+		& .findbar-textbox:focus {
+			outline: 1px solid
+				color-mix(
+					in hsl,
+					var(--better-findbar-background-color),
+					var(--better-findbar-text-color) 75%
+				) !important;
+			outline-offset: -1px !important;
+		}
+	}
 	&[hidden] {
 		transform: translateX(var(--better-findbar-transform-translateX)) translateY(var(--better-findbar-transform-translateY));
 	}

--- a/chrome.css
+++ b/chrome.css
@@ -1,242 +1,197 @@
+
 :root {
-    --better-findbar-transform-translateY: 150px;
-    --better-findbar-transform-translateX: -50%;
-    --better-findbar-position-top: auto;
-    --better-findbar-position-bottom: 15px;
-    --better-findbar-position-left: 50%;
-    --better-findbar-position-right: auto;
-    --better-findbar-background-color: var(--zen-primary-color);
-    --better-findbar-text-color: var(--zen-secondary-color);
-    --better-findbar-box-shadow: var(--box-shadow-10);
+	--better-findbar-transform-translateY: 150px;
+	--better-findbar-transform-translateX: -50%;
+	--better-findbar-position-top: auto;
+	--better-findbar-position-bottom: 15px;
+	--better-findbar-position-left: 50%;
+	--better-findbar-position-right: auto;
+	--better-findbar-background-color: var(--zen-primary-color);
 }
 
 /* Custom background */
 @media (-moz-bool-pref: "theme-better_find_bar-enable_custom_background") {
-    :root {
-        --better-findbar-background-color: var(--theme-better_find_bar-custom_background);
-    }
-}
-
-/* Custom text color */
-@media (-moz-bool-pref: "theme-better_find_bar-enable_custom_text_color") {
-    :root {
-        --better-findbar-text-color: var(--theme-better_find_bar-custom_text_color);
-    }
-}
-
-/* Custom box shadow */
-@media (-moz-bool-pref: "theme-better_find_bar-enable_custom_box_shadow") {
-    :root {
-        --better-findbar-box-shadow: var(--theme-better_find_bar-custom_box_shadow);
-    }
+	:root {
+		--better-findbar-background-color: var(--theme-better_find_bar-custom_background);
+	}
 }
 
 findbar {
-    display: flex !important;
+	display: flex !important;
 
-    border-radius: var(--zen-border-radius) !important;
-    margin: 0px !important;
+	border-radius: var(--zen-border-radius) !important;
+	margin: 0px !important;
 
-    width: 90% !important;
-    max-width: calc(var(--theme-better_find_bar-textbox_width) * 1px);
+	width: 90% !important;
+	max-width: calc(var(--theme-better_find_bar-textbox_width) * 1px); 
 
-    height: auto !important;
+	height: auto !important;
 
-    position: absolute !important;
-    top: var(--better-findbar-position-top);
-    bottom: var(--better-findbar-position-bottom);
-    left: var(--better-findbar-position-left);
-    right: var(--better-findbar-position-right);
-    transform: translateX(var(--better-findbar-transform-translateX)) translateY(0);
+	position: absolute !important;
+	top: var(--better-findbar-position-top);
+	bottom: var(--better-findbar-position-bottom);
+	left: var(--better-findbar-position-left);
+	right: var(--better-findbar-position-right);
+	transform: translateX(var(--better-findbar-transform-translateX)) translateY(0);
 
-    overflow: unset !important;
-    box-shadow: var(--better-findbar-box-shadow);
+	overflow: unset !important;
+	box-shadow: var(--box-shadow-10);
 
-    background: var(--better-findbar-background-color) !important;
-    color: var(--better-findbar-text-color) !important;
-    border: 1px solid
-        color-mix(
-            in hsl,
-            var(--better-findbar-background-color) 75%,
-            var(--better-findbar-text-color)
-        ) !important;
+	background: var(--better-findbar-background-color) !important;
+	border: 1px solid var(--input-border-color) !important;
 
-    transition: transform 0.35s ease !important;
+	transition: transform 0.35s ease !important;
 
-    visibility: visible !important;
-    opacity: 1 !important;
+	visibility: visible !important;
+	opacity: 1 !important;
 
-    & .findbar-container {
-        flex-wrap: wrap;
-        overflow-x: auto !important;
-        height: auto !important;
+	& .findbar-container {
+		flex-wrap: wrap;
+		overflow-x: auto !important;
+		height: auto !important;
 
-        row-gap: 10px;
+		row-gap: 10px;
 
-        & > :first-child {
-            width: 100% !important;
-        }
+		& > :first-child {
+			width: 100% !important;
+		}
 
-        & .findbar-textbox {
-            flex-grow: 1;
-            background: var(--better-findbar-background-color) !important;
-            color: var(--better-findbar-text-color) !important;
-            border: 1px solid
-                color-mix(
-                    in hsl,
-                    var(--better-findbar-background-color),
-                    var(--better-findbar-text-color) 50%
-                ) !important;
+		& .findbar-textbox {
+			flex-grow: 1;
+		}
+	}
 
-            &[status="notfound"] {
-                background-color: color-mix(
-                    in srgb,
-                    var(--better-findbar-background-color),
-                    red 50%
-                ) !important;
-                color: inherit;
-            }
-        }
+	&[hidden] {
+		transform: translateX(var(--better-findbar-transform-translateX)) translateY(var(--better-findbar-transform-translateY));
+	}
 
-        & .findbar-textbox:focus {
-            outline: 1px solid
-                color-mix(
-                    in hsl,
-                    var(--better-findbar-background-color),
-                    var(--better-findbar-text-color) 75%
-                ) !important;
-            outline-offset: -1px !important;
-        }
-    }
-    &[hidden] {
-        transform: translateX(var(--better-findbar-transform-translateX))
-            translateY(var(--better-findbar-transform-translateY));
-    }
-
-    @starting-style {
-        transform: translateX(var(--better-findbar-transform-translateX))
-            translateY(var(--better-findbar-transform-translateY));
-    }
+	@starting-style {
+		transform: translateX(var(--better-findbar-transform-translateX)) translateY(var(--better-findbar-transform-translateY));
+	}
 }
 
 /* Disable animations */
 @media (-moz-bool-pref: "theme.better_find_bar.instant_animations") {
-    findbar,
-    findbar .findbar-container {
-        transition: initial !important;
-    }
+	findbar, findbar .findbar-container {
+		transition: initial !important;
+	}
 }
 
 /* Horizontal Position */
-body:has(#theme-Better-Find-Bar[theme-better_find_bar-horizontal_position="left"]) {
-    --better-findbar-transform-translateX: 0%;
-    --better-findbar-position-left: 15px;
-    --better-findbar-position-right: auto;
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-horizontal_position="left"]
+	) {
+	--better-findbar-transform-translateX: 0%;
+	--better-findbar-position-left: 15px;
+	--better-findbar-position-right: auto;
 }
 
-body:has(#theme-Better-Find-Bar[theme-better_find_bar-horizontal_position="right"]) {
-    --better-findbar-transform-translateX: 0%;
-    --better-findbar-position-left: auto;
-    --better-findbar-position-right: 15px;
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-horizontal_position="right"]
+	) {
+	--better-findbar-transform-translateX: 0%;
+	--better-findbar-position-left: auto;
+	--better-findbar-position-right: 15px;
 }
 
 /* Vertical Position */
-body:has(#theme-Better-Find-Bar[theme-better_find_bar-vertical_position="top"]) {
-    --better-findbar-transform-translateY: -150px;
-    --better-findbar-position-bottom: auto;
-    --better-findbar-position-top: 15px;
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-vertical_position="top"]
+	) {
+	--better-findbar-transform-translateY: -150px;
+	--better-findbar-position-bottom: auto;
+	--better-findbar-position-top: 15px;
 }
+
 
 /* Background blur */
 @media (-moz-bool-pref: "theme.better_find_bar.transparent_background") {
-    findbar,
-    findbar .findbar-textbox:not([status="notfound"]) {
-        backdrop-filter: blur(8px);
+	findbar,
+	findbar .findbar-textbox:not([status="notfound"]) {
+		backdrop-filter: blur(8px);
 
-        background: color-mix(
-            in hsl,
-            var(--better-findbar-background-color),
-            transparent 10%
-        ) !important;
-    }
+		background: color-mix(in hsl, var(--better-findbar-background-color), transparent 10%) !important;
+	}
 }
 
 /* Hide highlight checkbox */
 body:has(
-    #theme-Better-Find-Bar[theme-better_find_bar-hide_highlight="hide_immediately"]
-) {
-    findbar .findbar-highlight {
-        display: none !important;
-    }
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_highlight="hide_immediately"]
+	) {
+	findbar .findbar-highlight {
+		display: none !important;
+	}
 }
 
-body:has(#theme-Better-Find-Bar[theme-better_find_bar-hide_highlight="hide_on_disable"]) {
-    findbar checkbox.findbar-highlight:not([checked]) {
-        display: none !important;
-    }
+body:has(
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_highlight="hide_on_disable"]
+	) {
+	findbar checkbox.findbar-highlight:not([checked]) {
+		display: none !important;
+	}
 }
 
 /* Hide match case checkbox */
 body:has(
-    #theme-Better-Find-Bar[theme-better_find_bar-hide_match_case="hide_immediately"]
-) {
-    findbar .findbar-case-sensitive {
-        display: none !important;
-    }
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_case="hide_immediately"]
+	) {
+	findbar .findbar-case-sensitive {
+		display: none !important;
+	}
 }
 
 body:has(
-    #theme-Better-Find-Bar[theme-better_find_bar-hide_match_case="hide_on_disable"]
-) {
-    findbar checkbox.findbar-case-sensitive:not([checked]) {
-        display: none !important;
-    }
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_case="hide_on_disable"]
+	) {
+	findbar checkbox.findbar-case-sensitive:not([checked]) {
+		display: none !important;
+	}
 }
 
 /* Hide match diacritics checkbox */
 body:has(
-    #theme-Better-Find-Bar[theme-better_find_bar-hide_match_diacritics="hide_immediately"]
-) {
-    findbar .findbar-match-diacritics {
-        display: none !important;
-    }
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_diacritics="hide_immediately"]
+	) {
+	findbar .findbar-match-diacritics {
+		display: none !important;
+	}
 }
 
 body:has(
-    #theme-Better-Find-Bar[theme-better_find_bar-hide_match_diacritics="hide_on_disable"]
-) {
-    findbar checkbox.findbar-match-diacritics:not([checked]) {
-        display: none !important;
-    }
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_diacritics="hide_on_disable"]
+	) {
+	findbar checkbox.findbar-match-diacritics:not([checked]) {
+		display: none !important;
+	}
 }
 
 /* Hide whole words checkbox */
 body:has(
-    #theme-Better-Find-Bar[theme-better_find_bar-hide_whole_words="hide_immediately"]
-) {
-    findbar .findbar-entire-word {
-        display: none !important;
-    }
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_whole_words="hide_immediately"]
+	) {
+	findbar .findbar-entire-word {
+		display: none !important;
+	}
 }
 
 body:has(
-    #theme-Better-Find-Bar[theme-better_find_bar-hide_whole_words="hide_on_disable"]
-) {
-    findbar .findbar-entire-word:not([checked]) {
-        display: none !important;
-    }
+		#theme-Better-Find-Bar[theme-better_find_bar-hide_whole_words="hide_on_disable"]
+	) {
+	findbar .findbar-entire-word:not([checked]) {
+		display: none !important;
+	}
 }
 
 /* Hide find status label */
 @media (-moz-bool-pref: "theme.better_find_bar.hide_find_status") {
-    findbar .findbar-find-status {
-        display: none !important;
-    }
+	findbar .findbar-find-status {
+		display: none !important;
+	}
 }
 
 /* Hide found matches label */
 @media (-moz-bool-pref: "theme.better_find_bar.hide_found_matches") {
-    findbar .findbar-label.found-matches {
-        display: none !important;
-    }
+	findbar .findbar-label.found-matches {
+		display: none !important;
+	}
 }

--- a/chrome.css
+++ b/chrome.css
@@ -1,197 +1,242 @@
-
 :root {
-	--better-findbar-transform-translateY: 150px;
-	--better-findbar-transform-translateX: -50%;
-	--better-findbar-position-top: auto;
-	--better-findbar-position-bottom: 15px;
-	--better-findbar-position-left: 50%;
-	--better-findbar-position-right: auto;
-	--better-findbar-background-color: var(--zen-primary-color);
+    --better-findbar-transform-translateY: 150px;
+    --better-findbar-transform-translateX: -50%;
+    --better-findbar-position-top: auto;
+    --better-findbar-position-bottom: 15px;
+    --better-findbar-position-left: 50%;
+    --better-findbar-position-right: auto;
+    --better-findbar-background-color: var(--zen-primary-color);
+    --better-findbar-text-color: var(--zen-secondary-color);
+    --better-findbar-box-shadow: var(--box-shadow-10);
 }
 
 /* Custom background */
 @media (-moz-bool-pref: "theme-better_find_bar-enable_custom_background") {
-	:root {
-		--better-findbar-background-color: var(--theme-better_find_bar-custom_background);
-	}
+    :root {
+        --better-findbar-background-color: var(--theme-better_find_bar-custom_background);
+    }
+}
+
+/* Custom text color */
+@media (-moz-bool-pref: "theme-better_find_bar-enable_custom_text_color") {
+    :root {
+        --better-findbar-text-color: var(--theme-better_find_bar-custom_text_color);
+    }
+}
+
+/* Custom box shadow */
+@media (-moz-bool-pref: "theme-better_find_bar-enable_custom_box_shadow") {
+    :root {
+        --better-findbar-box-shadow: var(--theme-better_find_bar-custom_box_shadow);
+    }
 }
 
 findbar {
-	display: flex !important;
+    display: flex !important;
 
-	border-radius: var(--zen-border-radius) !important;
-	margin: 0px !important;
+    border-radius: var(--zen-border-radius) !important;
+    margin: 0px !important;
 
-	width: 90% !important;
-	max-width: calc(var(--theme-better_find_bar-textbox_width) * 1px); 
+    width: 90% !important;
+    max-width: calc(var(--theme-better_find_bar-textbox_width) * 1px);
 
-	height: auto !important;
+    height: auto !important;
 
-	position: absolute !important;
-	top: var(--better-findbar-position-top);
-	bottom: var(--better-findbar-position-bottom);
-	left: var(--better-findbar-position-left);
-	right: var(--better-findbar-position-right);
-	transform: translateX(var(--better-findbar-transform-translateX)) translateY(0);
+    position: absolute !important;
+    top: var(--better-findbar-position-top);
+    bottom: var(--better-findbar-position-bottom);
+    left: var(--better-findbar-position-left);
+    right: var(--better-findbar-position-right);
+    transform: translateX(var(--better-findbar-transform-translateX)) translateY(0);
 
-	overflow: unset !important;
-	box-shadow: var(--box-shadow-10);
+    overflow: unset !important;
+    box-shadow: var(--better-findbar-box-shadow);
 
-	background: var(--better-findbar-background-color) !important;
-	border: 1px solid var(--input-border-color) !important;
+    background: var(--better-findbar-background-color) !important;
+    color: var(--better-findbar-text-color) !important;
+    border: 1px solid
+        color-mix(
+            in hsl,
+            var(--better-findbar-background-color) 75%,
+            var(--better-findbar-text-color)
+        ) !important;
 
-	transition: transform 0.35s ease !important;
+    transition: transform 0.35s ease !important;
 
-	visibility: visible !important;
-	opacity: 1 !important;
+    visibility: visible !important;
+    opacity: 1 !important;
 
-	& .findbar-container {
-		flex-wrap: wrap;
-		overflow-x: auto !important;
-		height: auto !important;
+    & .findbar-container {
+        flex-wrap: wrap;
+        overflow-x: auto !important;
+        height: auto !important;
 
-		row-gap: 10px;
+        row-gap: 10px;
 
-		& > :first-child {
-			width: 100% !important;
-		}
+        & > :first-child {
+            width: 100% !important;
+        }
 
-		& .findbar-textbox {
-			flex-grow: 1;
-		}
-	}
+        & .findbar-textbox {
+            flex-grow: 1;
+            background: var(--better-findbar-background-color) !important;
+            color: var(--better-findbar-text-color) !important;
+            border: 1px solid
+                color-mix(
+                    in hsl,
+                    var(--better-findbar-background-color),
+                    var(--better-findbar-text-color) 50%
+                ) !important;
 
-	&[hidden] {
-		transform: translateX(var(--better-findbar-transform-translateX)) translateY(var(--better-findbar-transform-translateY));
-	}
+            &[status="notfound"] {
+                background-color: color-mix(
+                    in srgb,
+                    var(--better-findbar-background-color),
+                    red 50%
+                ) !important;
+                color: inherit;
+            }
+        }
 
-	@starting-style {
-		transform: translateX(var(--better-findbar-transform-translateX)) translateY(var(--better-findbar-transform-translateY));
-	}
+        & .findbar-textbox:focus {
+            outline: 1px solid
+                color-mix(
+                    in hsl,
+                    var(--better-findbar-background-color),
+                    var(--better-findbar-text-color) 75%
+                ) !important;
+            outline-offset: -1px !important;
+        }
+    }
+    &[hidden] {
+        transform: translateX(var(--better-findbar-transform-translateX))
+            translateY(var(--better-findbar-transform-translateY));
+    }
+
+    @starting-style {
+        transform: translateX(var(--better-findbar-transform-translateX))
+            translateY(var(--better-findbar-transform-translateY));
+    }
 }
 
 /* Disable animations */
 @media (-moz-bool-pref: "theme.better_find_bar.instant_animations") {
-	findbar, findbar .findbar-container {
-		transition: initial !important;
-	}
+    findbar,
+    findbar .findbar-container {
+        transition: initial !important;
+    }
 }
 
 /* Horizontal Position */
-body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-horizontal_position="left"]
-	) {
-	--better-findbar-transform-translateX: 0%;
-	--better-findbar-position-left: 15px;
-	--better-findbar-position-right: auto;
+body:has(#theme-Better-Find-Bar[theme-better_find_bar-horizontal_position="left"]) {
+    --better-findbar-transform-translateX: 0%;
+    --better-findbar-position-left: 15px;
+    --better-findbar-position-right: auto;
 }
 
-body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-horizontal_position="right"]
-	) {
-	--better-findbar-transform-translateX: 0%;
-	--better-findbar-position-left: auto;
-	--better-findbar-position-right: 15px;
+body:has(#theme-Better-Find-Bar[theme-better_find_bar-horizontal_position="right"]) {
+    --better-findbar-transform-translateX: 0%;
+    --better-findbar-position-left: auto;
+    --better-findbar-position-right: 15px;
 }
 
 /* Vertical Position */
-body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-vertical_position="top"]
-	) {
-	--better-findbar-transform-translateY: -150px;
-	--better-findbar-position-bottom: auto;
-	--better-findbar-position-top: 15px;
+body:has(#theme-Better-Find-Bar[theme-better_find_bar-vertical_position="top"]) {
+    --better-findbar-transform-translateY: -150px;
+    --better-findbar-position-bottom: auto;
+    --better-findbar-position-top: 15px;
 }
-
 
 /* Background blur */
 @media (-moz-bool-pref: "theme.better_find_bar.transparent_background") {
-	findbar,
-	findbar .findbar-textbox:not([status="notfound"]) {
-		backdrop-filter: blur(8px);
+    findbar,
+    findbar .findbar-textbox:not([status="notfound"]) {
+        backdrop-filter: blur(8px);
 
-		background: color-mix(in hsl, var(--better-findbar-background-color), transparent 10%) !important;
-	}
+        background: color-mix(
+            in hsl,
+            var(--better-findbar-background-color),
+            transparent 10%
+        ) !important;
+    }
 }
 
 /* Hide highlight checkbox */
 body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-hide_highlight="hide_immediately"]
-	) {
-	findbar .findbar-highlight {
-		display: none !important;
-	}
+    #theme-Better-Find-Bar[theme-better_find_bar-hide_highlight="hide_immediately"]
+) {
+    findbar .findbar-highlight {
+        display: none !important;
+    }
 }
 
-body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-hide_highlight="hide_on_disable"]
-	) {
-	findbar checkbox.findbar-highlight:not([checked]) {
-		display: none !important;
-	}
+body:has(#theme-Better-Find-Bar[theme-better_find_bar-hide_highlight="hide_on_disable"]) {
+    findbar checkbox.findbar-highlight:not([checked]) {
+        display: none !important;
+    }
 }
 
 /* Hide match case checkbox */
 body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_case="hide_immediately"]
-	) {
-	findbar .findbar-case-sensitive {
-		display: none !important;
-	}
+    #theme-Better-Find-Bar[theme-better_find_bar-hide_match_case="hide_immediately"]
+) {
+    findbar .findbar-case-sensitive {
+        display: none !important;
+    }
 }
 
 body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_case="hide_on_disable"]
-	) {
-	findbar checkbox.findbar-case-sensitive:not([checked]) {
-		display: none !important;
-	}
+    #theme-Better-Find-Bar[theme-better_find_bar-hide_match_case="hide_on_disable"]
+) {
+    findbar checkbox.findbar-case-sensitive:not([checked]) {
+        display: none !important;
+    }
 }
 
 /* Hide match diacritics checkbox */
 body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_diacritics="hide_immediately"]
-	) {
-	findbar .findbar-match-diacritics {
-		display: none !important;
-	}
+    #theme-Better-Find-Bar[theme-better_find_bar-hide_match_diacritics="hide_immediately"]
+) {
+    findbar .findbar-match-diacritics {
+        display: none !important;
+    }
 }
 
 body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-hide_match_diacritics="hide_on_disable"]
-	) {
-	findbar checkbox.findbar-match-diacritics:not([checked]) {
-		display: none !important;
-	}
+    #theme-Better-Find-Bar[theme-better_find_bar-hide_match_diacritics="hide_on_disable"]
+) {
+    findbar checkbox.findbar-match-diacritics:not([checked]) {
+        display: none !important;
+    }
 }
 
 /* Hide whole words checkbox */
 body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-hide_whole_words="hide_immediately"]
-	) {
-	findbar .findbar-entire-word {
-		display: none !important;
-	}
+    #theme-Better-Find-Bar[theme-better_find_bar-hide_whole_words="hide_immediately"]
+) {
+    findbar .findbar-entire-word {
+        display: none !important;
+    }
 }
 
 body:has(
-		#theme-Better-Find-Bar[theme-better_find_bar-hide_whole_words="hide_on_disable"]
-	) {
-	findbar .findbar-entire-word:not([checked]) {
-		display: none !important;
-	}
+    #theme-Better-Find-Bar[theme-better_find_bar-hide_whole_words="hide_on_disable"]
+) {
+    findbar .findbar-entire-word:not([checked]) {
+        display: none !important;
+    }
 }
 
 /* Hide find status label */
 @media (-moz-bool-pref: "theme.better_find_bar.hide_find_status") {
-	findbar .findbar-find-status {
-		display: none !important;
-	}
+    findbar .findbar-find-status {
+        display: none !important;
+    }
 }
 
 /* Hide found matches label */
 @media (-moz-bool-pref: "theme.better_find_bar.hide_found_matches") {
-	findbar .findbar-label.found-matches {
-		display: none !important;
-	}
+    findbar .findbar-label.found-matches {
+        display: none !important;
+    }
 }

--- a/preferences.json
+++ b/preferences.json
@@ -1,183 +1,156 @@
 [
-    {
-        "property": "theme-better_find_bar-enable_custom_background",
-        "label": "Enable custom background",
-        "type": "checkbox",
-        "defaultValue": false
-    },
-    {
-        "property": "theme.better_find_bar.custom_background",
-        "label": "Custom background HEX color",
-        "type": "string",
-        "defaultValue": "#112233",
-        "placeholder": "#112233"
-    },
-        {
-        "property": "theme.better_find_bar.transparent_background",
-        "label": "Transparent background (disable it if the background blur doesn't work)",
-        "type": "checkbox",
-        "defaultValue": true
-    },
-    {
-        "property": "theme-better_find_bar-enable_custom_text_color",
-        "label": "Enable custom text color",
-        "type": "checkbox",
-        "defaultValue": false
-    },
-    {
-        "property": "theme.better_find_bar.custom_text_color",
-        "label": "Custom text HEX color",
-        "type": "string",
-        "defaultValue": "#ffffff",
-        "placeholder": "#ffffff"
-    },
-    {
-        "property": "theme-better_find_bar-enable_custom_box_shadow",
-        "label": "Enable custom box shadow",
-        "type": "checkbox",
-        "defaultValue": false
-    },
-    {
-        "property": "theme.better_find_bar.custom_box_shadow",
-        "label": "Custom box shadow (full CSS box-shadow value)",
-        "type": "string",
-        "defaultValue": "0 5px 10px rgba(0,0,0,0.5)",
-        "placeholder": "0 5px 10px rgba(0,0,0,0.5)"
-    },
-    {
-        "property": "theme.better_find_bar.horizontal_position",
-        "label": "Horizontal position",
-        "type": "dropdown",
-        "disabledOn": [],
-        "placeholder": "Use default",
-        "defaultValue": "default",
-        "options": [
-            {
-                "label": "Left",
-                "value": "left"
-            },
-            {
-                "label": "Center",
-                "value": "default"
-            },
-            {
-                "label": "Right",
-                "value": "right"
-            }
-        ]
-    },
-    {
-        "property": "theme.better_find_bar.vertical_position",
-        "label": "Vertical position",
-        "type": "dropdown",
-        "disabledOn": [],
-        "placeholder": "Use default",
-        "defaultValue": "default",
-        "options": [
-            {
-                "label": "Top",
-                "value": "top"
-            },
-            {
-                "label": "Bottom",
-                "value": "default"
-            }
-        ]
-    },
-    {
-        "property": "theme.better_find_bar.textbox_width",
-        "label": "Textbox width (px)",
-        "type": "string",
-        "defaultValue": "800"
-    },
-    {
-        "property": "theme.better_find_bar.hide_highlight",
-        "label": "Hide \"highlight\" checkbox",
-        "type": "dropdown",
-        "disabledOn": [],
-        "placeholder": "Show",
-        "defaultValue": "not_hide",
-        "options": [
-            {
-                "label": "Hide",
-                "value": "hide_immediately"
-            },
-            {
-                "label": "Show only when checked",
-                "value": "hide_on_disable"
-            }
-        ]
-    },
-    {
-        "property": "theme.better_find_bar.hide_match_case",
-        "label": "Hide \"match case\" checkbox",
-        "type": "dropdown",
-        "disabledOn": [],
-        "placeholder": "Show",
-        "defaultValue": "not_hide",
-        "options": [
-            {
-                "label": "Hide",
-                "value": "hide_immediately"
-            },
-            {
-                "label": "Show only when checked",
-                "value": "hide_on_disable"
-            }
-        ]
-    },
-    {
-        "property": "theme.better_find_bar.hide_match_diacritics",
-        "label": "Hide \"match diacritics\" checkbox",
-        "type": "dropdown",
-        "disabledOn": [],
-        "placeholder": "Show",
-        "defaultValue": "not_hide",
-        "options": [
-            {
-                "label": "Hide",
-                "value": "hide_immediately"
-            },
-            {
-                "label": "Show only when checked",
-                "value": "hide_on_disable"
-            }
-        ]
-    },
-    {
-        "property": "theme.better_find_bar.hide_whole_words",
-        "label": "Hide \"whole words\" checkbox",
-        "type": "dropdown",
-        "disabledOn": [],
-        "placeholder": "Show",
-        "defaultValue": "not_hide",
-        "options": [
-            {
-                "label": "Hide",
-                "value": "hide_immediately"
-            },
-            {
-                "label": "Show only when checked",
-                "value": "hide_on_disable"
-            }
-        ]
-    },
-    {
-        "property": "theme.better_find_bar.instant_animations",
-        "label": "Instant animations",
-        "type": "checkbox",
-        "defaultValue": false
-    },
-    {
-        "property": "theme.better_find_bar.hide_find_status",
-        "label": "Hide find status label",
-        "type": "checkbox",
-        "defaultValue": false
-    },
-    {
-        "property": "theme.better_find_bar.hide_found_matches",
-        "label": "Hide found matches label",
-        "type": "checkbox",
-        "defaultValue": false
-    }
+{
+		"property": "theme-better_find_bar-enable_custom_background",
+		"label": "Enable custom background",
+		"type": "checkbox",
+		"defaultValue": false
+	},
+	{
+		"property": "theme.better_find_bar.custom_background",
+		"label": "Custom background HEX color",
+		"type": "string",
+		"defaultValue": "#112233"
+	},
+	{
+		"property": "theme.better_find_bar.transparent_background",
+		"label": "Transparent background (disable it if the background blur doesn't work)",
+		"type": "checkbox",
+		"defaultValue": true
+	},
+	{
+		"property": "theme.better_find_bar.horizontal_position",
+		"label": "Horizontal position",
+		"type": "dropdown",
+		"disabledOn": [],
+		"placeholder": "Use default",
+		"defaultValue": "default",
+		"options": [
+			{
+				"label": "Left",
+				"value": "left"
+			},
+			{
+				"label": "Center",
+				"value": "default"
+			},
+			{
+				"label": "Right",
+				"value": "right"
+			}
+		]
+	},
+	{
+		"property": "theme.better_find_bar.vertical_position",
+		"label": "Vertical position",
+		"type": "dropdown",
+		"disabledOn": [],
+		"placeholder": "Use default",
+		"defaultValue": "default",
+		"options": [
+			{
+				"label": "Top",
+				"value": "top"
+			},
+			{
+				"label": "Bottom",
+				"value": "default"
+			}
+		]
+	},
+	{
+		"property": "theme.better_find_bar.textbox_width",
+		"label": "Textbox width (px)",
+		"type": "string",
+		"defaultValue": "800"
+	},
+	{
+		"property": "theme.better_find_bar.hide_highlight",
+		"label": "Hide \"highlight\" checkbox",
+		"type": "dropdown",
+		"disabledOn": [],
+		"placeholder": "Show",
+		"defaultValue": "not_hide",
+		"options": [
+			{
+				"label": "Hide",
+				"value": "hide_immediately"
+			},
+			{
+				"label": "Show only when checked",
+				"value": "hide_on_disable"
+			}
+		]
+	},
+	{
+		"property": "theme.better_find_bar.hide_match_case",
+		"label": "Hide \"match case\" checkbox",
+		"type": "dropdown",
+		"disabledOn": [],
+		"placeholder": "Show",
+		"defaultValue": "not_hide",
+		"options": [
+			{
+				"label": "Hide",
+				"value": "hide_immediately"
+			},
+			{
+				"label": "Show only when checked",
+				"value": "hide_on_disable"
+			}
+		]
+	},
+	{
+		"property": "theme.better_find_bar.hide_match_diacritics",
+		"label": "Hide \"match diacritics\" checkbox",
+		"type": "dropdown",
+		"disabledOn": [],
+		"placeholder": "Show",
+		"defaultValue": "not_hide",
+		"options": [
+			{
+				"label": "Hide",
+				"value": "hide_immediately"
+			},
+			{
+				"label": "Show only when checked",
+				"value": "hide_on_disable"
+			}
+		]
+	},
+	{
+		"property": "theme.better_find_bar.hide_whole_words",
+		"label": "Hide \"whole words\" checkbox",
+		"type": "dropdown",
+		"disabledOn": [],
+		"placeholder": "Show",
+		"defaultValue": "not_hide",
+		"options": [
+			{
+				"label": "Hide",
+				"value": "hide_immediately"
+			},
+			{
+				"label": "Show only when checked",
+				"value": "hide_on_disable"
+			}
+		]
+	},
+	{
+		"property": "theme.better_find_bar.instant_animations",
+		"label": "Instant animations",
+		"type": "checkbox",
+		"defaultValue": false
+	},
+	{
+		"property": "theme.better_find_bar.hide_find_status",
+		"label": "Hide find status label",
+		"type": "checkbox",
+		"defaultValue": false
+	},
+	{
+		"property": "theme.better_find_bar.hide_found_matches",
+		"label": "Hide found matches label",
+		"type": "checkbox",
+		"defaultValue": false
+	}
 ]

--- a/preferences.json
+++ b/preferences.json
@@ -9,13 +9,40 @@
 		"property": "theme.better_find_bar.custom_background",
 		"label": "Custom background HEX color",
 		"type": "string",
-		"defaultValue": "#112233"
+		"defaultValue": "#112233",
+		"placeholder": "#112233"
 	},
 	{
 		"property": "theme.better_find_bar.transparent_background",
 		"label": "Transparent background (disable it if the background blur doesn't work)",
 		"type": "checkbox",
 		"defaultValue": true
+	},
+	{
+		"property": "theme-better_find_bar-enable_custom_text_color",
+		"label": "Enable custom text color",
+		"type": "checkbox",
+		"defaultValue": false
+	},
+	{
+		"property": "theme.better_find_bar.custom_text_color",
+		"label": "Custom text HEX color",
+		"type": "string",
+		"defaultValue": "#ffffff",
+		"placeholder": "#ffffff"
+	},
+	{
+		"property": "theme-better_find_bar-enable_custom_box_shadow",
+		"label": "Enable custom box shadow",
+		"type": "checkbox",
+		"defaultValue": false
+	},
+	{
+		"property": "theme.better_find_bar.custom_box_shadow",
+		"label": "Custom box shadow (full CSS box-shadow value)",
+		"type": "string",
+		"defaultValue": "0 5px 10px rgba(0,0,0,0.5)",
+		"placeholder": "0 5px 10px rgba(0,0,0,0.5)"
 	},
 	{
 		"property": "theme.better_find_bar.horizontal_position",

--- a/preferences.json
+++ b/preferences.json
@@ -1,156 +1,183 @@
 [
-{
-		"property": "theme-better_find_bar-enable_custom_background",
-		"label": "Enable custom background",
-		"type": "checkbox",
-		"defaultValue": false
-	},
-	{
-		"property": "theme.better_find_bar.custom_background",
-		"label": "Custom background HEX color",
-		"type": "string",
-		"defaultValue": "#112233"
-	},
-	{
-		"property": "theme.better_find_bar.transparent_background",
-		"label": "Transparent background (disable it if the background blur doesn't work)",
-		"type": "checkbox",
-		"defaultValue": true
-	},
-	{
-		"property": "theme.better_find_bar.horizontal_position",
-		"label": "Horizontal position",
-		"type": "dropdown",
-		"disabledOn": [],
-		"placeholder": "Use default",
-		"defaultValue": "default",
-		"options": [
-			{
-				"label": "Left",
-				"value": "left"
-			},
-			{
-				"label": "Center",
-				"value": "default"
-			},
-			{
-				"label": "Right",
-				"value": "right"
-			}
-		]
-	},
-	{
-		"property": "theme.better_find_bar.vertical_position",
-		"label": "Vertical position",
-		"type": "dropdown",
-		"disabledOn": [],
-		"placeholder": "Use default",
-		"defaultValue": "default",
-		"options": [
-			{
-				"label": "Top",
-				"value": "top"
-			},
-			{
-				"label": "Bottom",
-				"value": "default"
-			}
-		]
-	},
-	{
-		"property": "theme.better_find_bar.textbox_width",
-		"label": "Textbox width (px)",
-		"type": "string",
-		"defaultValue": "800"
-	},
-	{
-		"property": "theme.better_find_bar.hide_highlight",
-		"label": "Hide \"highlight\" checkbox",
-		"type": "dropdown",
-		"disabledOn": [],
-		"placeholder": "Show",
-		"defaultValue": "not_hide",
-		"options": [
-			{
-				"label": "Hide",
-				"value": "hide_immediately"
-			},
-			{
-				"label": "Show only when checked",
-				"value": "hide_on_disable"
-			}
-		]
-	},
-	{
-		"property": "theme.better_find_bar.hide_match_case",
-		"label": "Hide \"match case\" checkbox",
-		"type": "dropdown",
-		"disabledOn": [],
-		"placeholder": "Show",
-		"defaultValue": "not_hide",
-		"options": [
-			{
-				"label": "Hide",
-				"value": "hide_immediately"
-			},
-			{
-				"label": "Show only when checked",
-				"value": "hide_on_disable"
-			}
-		]
-	},
-	{
-		"property": "theme.better_find_bar.hide_match_diacritics",
-		"label": "Hide \"match diacritics\" checkbox",
-		"type": "dropdown",
-		"disabledOn": [],
-		"placeholder": "Show",
-		"defaultValue": "not_hide",
-		"options": [
-			{
-				"label": "Hide",
-				"value": "hide_immediately"
-			},
-			{
-				"label": "Show only when checked",
-				"value": "hide_on_disable"
-			}
-		]
-	},
-	{
-		"property": "theme.better_find_bar.hide_whole_words",
-		"label": "Hide \"whole words\" checkbox",
-		"type": "dropdown",
-		"disabledOn": [],
-		"placeholder": "Show",
-		"defaultValue": "not_hide",
-		"options": [
-			{
-				"label": "Hide",
-				"value": "hide_immediately"
-			},
-			{
-				"label": "Show only when checked",
-				"value": "hide_on_disable"
-			}
-		]
-	},
-	{
-		"property": "theme.better_find_bar.instant_animations",
-		"label": "Instant animations",
-		"type": "checkbox",
-		"defaultValue": false
-	},
-	{
-		"property": "theme.better_find_bar.hide_find_status",
-		"label": "Hide find status label",
-		"type": "checkbox",
-		"defaultValue": false
-	},
-	{
-		"property": "theme.better_find_bar.hide_found_matches",
-		"label": "Hide found matches label",
-		"type": "checkbox",
-		"defaultValue": false
-	}
+    {
+        "property": "theme-better_find_bar-enable_custom_background",
+        "label": "Enable custom background",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
+        "property": "theme.better_find_bar.custom_background",
+        "label": "Custom background HEX color",
+        "type": "string",
+        "defaultValue": "#112233",
+        "placeholder": "#112233"
+    },
+        {
+        "property": "theme.better_find_bar.transparent_background",
+        "label": "Transparent background (disable it if the background blur doesn't work)",
+        "type": "checkbox",
+        "defaultValue": true
+    },
+    {
+        "property": "theme-better_find_bar-enable_custom_text_color",
+        "label": "Enable custom text color",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
+        "property": "theme.better_find_bar.custom_text_color",
+        "label": "Custom text HEX color",
+        "type": "string",
+        "defaultValue": "#ffffff",
+        "placeholder": "#ffffff"
+    },
+    {
+        "property": "theme-better_find_bar-enable_custom_box_shadow",
+        "label": "Enable custom box shadow",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
+        "property": "theme.better_find_bar.custom_box_shadow",
+        "label": "Custom box shadow (full CSS box-shadow value)",
+        "type": "string",
+        "defaultValue": "0 5px 10px rgba(0,0,0,0.5)",
+        "placeholder": "0 5px 10px rgba(0,0,0,0.5)"
+    },
+    {
+        "property": "theme.better_find_bar.horizontal_position",
+        "label": "Horizontal position",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Use default",
+        "defaultValue": "default",
+        "options": [
+            {
+                "label": "Left",
+                "value": "left"
+            },
+            {
+                "label": "Center",
+                "value": "default"
+            },
+            {
+                "label": "Right",
+                "value": "right"
+            }
+        ]
+    },
+    {
+        "property": "theme.better_find_bar.vertical_position",
+        "label": "Vertical position",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Use default",
+        "defaultValue": "default",
+        "options": [
+            {
+                "label": "Top",
+                "value": "top"
+            },
+            {
+                "label": "Bottom",
+                "value": "default"
+            }
+        ]
+    },
+    {
+        "property": "theme.better_find_bar.textbox_width",
+        "label": "Textbox width (px)",
+        "type": "string",
+        "defaultValue": "800"
+    },
+    {
+        "property": "theme.better_find_bar.hide_highlight",
+        "label": "Hide \"highlight\" checkbox",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Show",
+        "defaultValue": "not_hide",
+        "options": [
+            {
+                "label": "Hide",
+                "value": "hide_immediately"
+            },
+            {
+                "label": "Show only when checked",
+                "value": "hide_on_disable"
+            }
+        ]
+    },
+    {
+        "property": "theme.better_find_bar.hide_match_case",
+        "label": "Hide \"match case\" checkbox",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Show",
+        "defaultValue": "not_hide",
+        "options": [
+            {
+                "label": "Hide",
+                "value": "hide_immediately"
+            },
+            {
+                "label": "Show only when checked",
+                "value": "hide_on_disable"
+            }
+        ]
+    },
+    {
+        "property": "theme.better_find_bar.hide_match_diacritics",
+        "label": "Hide \"match diacritics\" checkbox",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Show",
+        "defaultValue": "not_hide",
+        "options": [
+            {
+                "label": "Hide",
+                "value": "hide_immediately"
+            },
+            {
+                "label": "Show only when checked",
+                "value": "hide_on_disable"
+            }
+        ]
+    },
+    {
+        "property": "theme.better_find_bar.hide_whole_words",
+        "label": "Hide \"whole words\" checkbox",
+        "type": "dropdown",
+        "disabledOn": [],
+        "placeholder": "Show",
+        "defaultValue": "not_hide",
+        "options": [
+            {
+                "label": "Hide",
+                "value": "hide_immediately"
+            },
+            {
+                "label": "Show only when checked",
+                "value": "hide_on_disable"
+            }
+        ]
+    },
+    {
+        "property": "theme.better_find_bar.instant_animations",
+        "label": "Instant animations",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
+        "property": "theme.better_find_bar.hide_find_status",
+        "label": "Hide find status label",
+        "type": "checkbox",
+        "defaultValue": false
+    },
+    {
+        "property": "theme.better_find_bar.hide_found_matches",
+        "label": "Hide found matches label",
+        "type": "checkbox",
+        "defaultValue": false
+    }
 ]


### PR DESCRIPTION
- Custom text color option has been added (with default)
- Custom box shadow option has been added (with default)
- All `string` preferences types have had `placeholder` fields added
- `findbar textbox` has been styled according to default zen colors _or_ custom colors for a more consistent look
- Reference to `--zen-primary-color` was replaced with `--zen-colors-primary` so I could also reference `--zen-colors-secondary` (since these are both generated from `--zen-primary-color`)
- Removed reference to CSS variable `--box-shadow-10` as I [couldn't find it in the zen codebase](https://github.com/search?q=repo%3Azen-browser%2Fdesktop+--box-shadow-10&type=code). Replaced it with a default box shadow value.

Great work on the mod by the way! It was really easy to configure, and really easy to jump in and make changes too.